### PR TITLE
[YOUQ-77] 로그아웃 API 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,7 @@ configurations {
 dependencies {
     implementation("org.springframework.kafka:spring-kafka")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springframework.boot:spring-boot-starter-data-redis-reactive")
     implementation("org.springframework.boot:spring-boot-starter-log4j2")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-webflux")

--- a/src/main/kotlin/com/youquiz/authentication/domain/Token.kt
+++ b/src/main/kotlin/com/youquiz/authentication/domain/Token.kt
@@ -1,0 +1,6 @@
+package com.youquiz.authentication.domain
+
+data class Token(
+    val userId: Long,
+    val content: String
+)

--- a/src/main/kotlin/com/youquiz/authentication/global/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/com/youquiz/authentication/global/config/SecurityConfiguration.kt
@@ -27,7 +27,9 @@ class SecurityConfiguration {
             httpBasic { it.authenticationEntryPoint(HttpStatusServerEntryPoint(HttpStatus.UNAUTHORIZED)) }
             securityContextRepository(NoOpServerSecurityContextRepository.getInstance())
             authorizeExchange {
-                it.anyExchange()
+                it.pathMatchers("/auth/logout")
+                    .authenticated()
+                    .anyExchange()
                     .permitAll()
             }
             addFilterAt(JwtAuthenticationFilter(jwtProvider), SecurityWebFiltersOrder.AUTHORIZATION)

--- a/src/main/kotlin/com/youquiz/authentication/handler/AuthenticationHandler.kt
+++ b/src/main/kotlin/com/youquiz/authentication/handler/AuthenticationHandler.kt
@@ -1,20 +1,23 @@
 package com.youquiz.authentication.handler
 
+import com.github.jwt.authentication.JwtAuthentication
 import com.youquiz.authentication.dto.LoginRequest
 import com.youquiz.authentication.service.AuthenticationService
 import org.springframework.stereotype.Component
-import org.springframework.web.reactive.function.server.ServerRequest
-import org.springframework.web.reactive.function.server.ServerResponse
-import org.springframework.web.reactive.function.server.awaitBody
-import org.springframework.web.reactive.function.server.bodyValueAndAwait
+import org.springframework.web.reactive.function.server.*
 
 @Component
 class AuthenticationHandler(
     private val authenticationService: AuthenticationService
 ) {
-    suspend fun login(serverRequest: ServerRequest): ServerResponse {
-        val loginRequest = serverRequest.awaitBody<LoginRequest>()
+    suspend fun login(serverRequest: ServerRequest): ServerResponse =
+        serverRequest.awaitBody<LoginRequest>().let {
+            ServerResponse.ok().bodyValueAndAwait(authenticationService.login(it))
+        }
 
-        return ServerResponse.ok().bodyValueAndAwait(authenticationService.login(loginRequest))
-    }
+    suspend fun logout(request: ServerRequest): ServerResponse =
+        with(request.awaitPrincipal() as JwtAuthentication) {
+            authenticationService.logout(id)
+            ServerResponse.ok().buildAndAwait()
+        }
 }

--- a/src/main/kotlin/com/youquiz/authentication/repository/TokenRepository.kt
+++ b/src/main/kotlin/com/youquiz/authentication/repository/TokenRepository.kt
@@ -1,0 +1,42 @@
+package com.youquiz.authentication.repository
+
+import com.youquiz.authentication.domain.Token
+import kotlinx.coroutines.reactor.awaitSingle
+import kotlinx.coroutines.reactor.awaitSingleOrNull
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.data.redis.core.ReactiveRedisTemplate
+import org.springframework.stereotype.Repository
+import java.time.Duration
+
+@Repository
+class TokenRepository(
+    private val redisTemplate: ReactiveRedisTemplate<String, String>,
+    @Value("\${jwt.refreshTokenExpire}")
+    private val expire: Long
+) {
+    suspend fun findByUserId(userId: Long): Token? =
+        redisTemplate.opsForValue()
+            .get(getKey(userId))
+            .awaitSingleOrNull()?.let {
+                Token(
+                    userId = userId,
+                    content = it
+                )
+            }
+
+    suspend fun save(token: Token): Boolean =
+        with(token) {
+            redisTemplate.run {
+                val key = getKey(userId)
+
+                opsForValue().set(key, content, Duration.ofMinutes(expire)).awaitSingle()
+            }
+        }
+
+    suspend fun deleteByUserId(userId: Long): Boolean =
+        redisTemplate.opsForValue()
+            .delete(getKey(userId))
+            .awaitSingle()
+
+    private fun getKey(id: Long): String = "refreshToken:$id"
+}

--- a/src/main/kotlin/com/youquiz/authentication/router/AuthenticationRouter.kt
+++ b/src/main/kotlin/com/youquiz/authentication/router/AuthenticationRouter.kt
@@ -14,6 +14,7 @@ class AuthenticationRouter {
         coRouter {
             "/auth".nest {
                 POST("/login", handler::login)
+                GET("/logout", handler::logout)
             }
         }
 }

--- a/src/main/kotlin/com/youquiz/authentication/service/AuthenticationService.kt
+++ b/src/main/kotlin/com/youquiz/authentication/service/AuthenticationService.kt
@@ -6,12 +6,14 @@ import com.youquiz.authentication.adapter.client.UserClient
 import com.youquiz.authentication.dto.LoginRequest
 import com.youquiz.authentication.dto.LoginResponse
 import com.youquiz.authentication.exception.PasswordNotMatchException
+import com.youquiz.authentication.repository.TokenRepository
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 
 @Service
 class AuthenticationService(
+    private val tokenRepository: TokenRepository,
     private val userClient: UserClient,
     private val jwtProvider: JwtProvider,
     private val passwordEncoder: PasswordEncoder
@@ -28,5 +30,9 @@ class AuthenticationService(
 
             return LoginResponse(accessToken = accessToken, refreshToken = refreshToken)
         } else throw PasswordNotMatchException()
+    }
+
+    suspend fun logout(userId: Long) {
+        tokenRepository.deleteByUserId(userId)
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,4 @@
 jwt:
   secretKey: dasdsaddsaldldasjdjdajkdjkdsakjldasjkldkjldas
-  accessTokenExpire: 30
-  refreshTokenExpire: 120
+  accessTokenExpire: 5
+  refreshTokenExpire: 10

--- a/src/test/kotlin/com/youquiz/authentication/config/RedisTestConfiguration.kt
+++ b/src/test/kotlin/com/youquiz/authentication/config/RedisTestConfiguration.kt
@@ -1,0 +1,19 @@
+package com.youquiz.authentication.config
+
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.ReactiveRedisTemplate
+import org.springframework.data.redis.serializer.RedisSerializationContext
+
+@TestConfiguration
+class RedisTestConfiguration {
+    @Bean
+    fun redisConnectionFactory(): LettuceConnectionFactory =
+        LettuceConnectionFactory(RedisStandaloneConfiguration("localhost", 6379))
+
+    @Bean
+    fun reactiveRedisTemplate(): ReactiveRedisTemplate<String, String> =
+        ReactiveRedisTemplate(redisConnectionFactory(), RedisSerializationContext.string())
+}

--- a/src/test/kotlin/com/youquiz/authentication/controller/AuthenticationControllerTest.kt
+++ b/src/test/kotlin/com/youquiz/authentication/controller/AuthenticationControllerTest.kt
@@ -7,9 +7,9 @@ import com.youquiz.authentication.dto.LoginRequest
 import com.youquiz.authentication.dto.LoginResponse
 import com.youquiz.authentication.exception.PasswordNotMatchException
 import com.youquiz.authentication.exception.UserNotFoundException
-import com.youquiz.authentication.fixture.JWT_AUTHENTICATION
 import com.youquiz.authentication.fixture.PASSWORD
 import com.youquiz.authentication.fixture.USERNAME
+import com.youquiz.authentication.fixture.createJwtAuthentication
 import com.youquiz.authentication.fixture.jwtProvider
 import com.youquiz.authentication.global.dto.ErrorResponse
 import com.youquiz.authentication.handler.AuthenticationHandler
@@ -38,8 +38,8 @@ class AuthenticationControllerTest : BaseControllerTest() {
     )
 
     private val loginResponse = LoginResponse(
-        accessToken = jwtProvider.createAccessToken(JWT_AUTHENTICATION),
-        refreshToken = jwtProvider.createRefreshToken(JWT_AUTHENTICATION)
+        accessToken = jwtProvider.createAccessToken(createJwtAuthentication()),
+        refreshToken = jwtProvider.createRefreshToken(createJwtAuthentication())
     )
 
     init {

--- a/src/test/kotlin/com/youquiz/authentication/controller/AuthenticationControllerTest.kt
+++ b/src/test/kotlin/com/youquiz/authentication/controller/AuthenticationControllerTest.kt
@@ -18,6 +18,7 @@ import com.youquiz.authentication.service.AuthenticationService
 import com.youquiz.authentication.util.BaseControllerTest
 import com.youquiz.authentication.util.desc
 import com.youquiz.authentication.util.errorResponseFields
+import com.youquiz.authentication.util.withMockUser
 import io.mockk.coEvery
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
 import org.springframework.restdocs.operation.preprocess.Preprocessors.*
@@ -124,6 +125,40 @@ class AuthenticationControllerTest : BaseControllerTest() {
                                 responseFields(errorResponseFields)
                             )
                         )
+                }
+            }
+        }
+
+
+        describe("logout()은") {
+            context("요청을 보낸 유저가 로그인 상태인 경우") {
+                coEvery { authenticationService.logout(any()) } returns Unit
+                withMockUser()
+
+                it("상태 코드 200을 반환한다.") {
+                    webClient
+                        .get()
+                        .uri("/auth/logout")
+                        .exchange()
+                        .expectStatus()
+                        .isOk
+                        .expectBody()
+                        .consumeWith(WebTestClientRestDocumentationWrapper.document("로그아웃 성공(200)"))
+                }
+            }
+
+            context("요청을 보낸 유저가 로그인 상태가 아닌 경우") {
+                coEvery { authenticationService.logout(any()) } returns Unit
+
+                it("상태 코드 401을 반환한다.") {
+                    webClient
+                        .get()
+                        .uri("/auth/logout")
+                        .exchange()
+                        .expectStatus()
+                        .isUnauthorized
+                        .expectBody()
+                        .consumeWith(WebTestClientRestDocumentationWrapper.document("로그아웃 실패(401)"))
                 }
             }
         }

--- a/src/test/kotlin/com/youquiz/authentication/fixture/CommonFixture.kt
+++ b/src/test/kotlin/com/youquiz/authentication/fixture/CommonFixture.kt
@@ -1,0 +1,3 @@
+package com.youquiz.authentication.fixture
+
+const val ID = 1L

--- a/src/test/kotlin/com/youquiz/authentication/fixture/JwtFixture.kt
+++ b/src/test/kotlin/com/youquiz/authentication/fixture/JwtFixture.kt
@@ -2,6 +2,8 @@ package com.youquiz.authentication.fixture
 
 import com.github.jwt.authentication.DefaultJwtAuthentication
 import com.github.jwt.config.JwtConfiguration
+import com.youquiz.authentication.domain.Token
+import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 
 val SECRET_KEY = (1..100).map { ('a'..'z').random() }.joinToString("")
@@ -9,8 +11,23 @@ const val ACCESS_TOKEN_EXPIRE = 5L
 const val REFRESH_TOKEN_EXPIRE = 10L
 val AUTHORITIES = listOf(SimpleGrantedAuthority(ROLE.name))
 const val INVALID_TOKEN = "test"
-val JWT_AUTHENTICATION = DefaultJwtAuthentication(id = ID, authorities = AUTHORITIES)
-
 val jwtProvider = JwtConfiguration().jwtProvider(
     secretKey = SECRET_KEY, accessTokenExpire = ACCESS_TOKEN_EXPIRE, refreshTokenExpire = REFRESH_TOKEN_EXPIRE
+)
+
+fun createJwtAuthentication(
+    id: Long = ID,
+    authorities: List<GrantedAuthority> = AUTHORITIES
+): DefaultJwtAuthentication =
+    DefaultJwtAuthentication(
+        id = id,
+        authorities = authorities
+    )
+
+fun createToken(
+    userId: Long = ID,
+    content: String = jwtProvider.createRefreshToken(createJwtAuthentication())
+): Token = Token(
+    userId = userId,
+    content = content
 )

--- a/src/test/kotlin/com/youquiz/authentication/fixture/JwtFixture.kt
+++ b/src/test/kotlin/com/youquiz/authentication/fixture/JwtFixture.kt
@@ -5,8 +5,8 @@ import com.github.jwt.config.JwtConfiguration
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 
 val SECRET_KEY = (1..100).map { ('a'..'z').random() }.joinToString("")
-const val ACCESS_TOKEN_EXPIRE = 30L
-const val REFRESH_TOKEN_EXPIRE = 120L
+const val ACCESS_TOKEN_EXPIRE = 5L
+const val REFRESH_TOKEN_EXPIRE = 10L
 val AUTHORITIES = listOf(SimpleGrantedAuthority(ROLE.name))
 const val INVALID_TOKEN = "test"
 val JWT_AUTHENTICATION = DefaultJwtAuthentication(id = ID, authorities = AUTHORITIES)

--- a/src/test/kotlin/com/youquiz/authentication/fixture/UserFixture.kt
+++ b/src/test/kotlin/com/youquiz/authentication/fixture/UserFixture.kt
@@ -4,15 +4,20 @@ import com.youquiz.authentication.domain.User
 import com.youquiz.authentication.domain.enum.Role
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 
-const val ID = 1L
 const val USERNAME = "earlgrey02"
 const val PASSWORD = "root"
 val ROLE = Role.USER
 const val INVALID_USERNAME = "test"
 const val INVALID_PASSWORD = "test"
-val USER = User(
-    id = ID,
-    username = USERNAME,
-    password = BCryptPasswordEncoder().encode(PASSWORD),
-    role = ROLE
+
+fun createUser(
+    id: Long = ID,
+    username: String = USERNAME,
+    password: String = PASSWORD,
+    role: Role = ROLE
+) = User(
+    id = id,
+    username = username,
+    password = BCryptPasswordEncoder().encode(password),
+    role = role
 )

--- a/src/test/kotlin/com/youquiz/authentication/repository/TokenRepositoryTest.kt
+++ b/src/test/kotlin/com/youquiz/authentication/repository/TokenRepositoryTest.kt
@@ -3,8 +3,8 @@ package com.youquiz.authentication.repository
 import com.youquiz.authentication.config.RedisTestConfiguration
 import com.youquiz.authentication.domain.Token
 import com.youquiz.authentication.fixture.ID
-import com.youquiz.authentication.fixture.JWT_AUTHENTICATION
 import com.youquiz.authentication.fixture.REFRESH_TOKEN_EXPIRE
+import com.youquiz.authentication.fixture.createJwtAuthentication
 import com.youquiz.authentication.fixture.jwtProvider
 import io.kotest.core.spec.style.ExpectSpec
 import io.kotest.core.test.TestCase
@@ -29,14 +29,17 @@ class TokenRepositoryTest : ExpectSpec() {
     }
 
     override suspend fun beforeContainer(testCase: TestCase) {
-        redisTemplate.execute { it.serverCommands().flushAll() }.awaitSingle()
+        redisTemplate.execute {
+            it.serverCommands()
+                .flushAll()
+        }.awaitSingle()
     }
 
     init {
         context("리프레쉬 토큰 조회") {
             val refreshToken = Token(
                 userId = ID,
-                content = jwtProvider.createRefreshToken(JWT_AUTHENTICATION)
+                content = jwtProvider.createRefreshToken(createJwtAuthentication())
             ).also { tokenRepository.save(it) }
 
             expect("특정 유저의 리프레쉬 토큰을 조회한다.") {
@@ -47,7 +50,7 @@ class TokenRepositoryTest : ExpectSpec() {
         context("리프레쉬 토큰 수정") {
             val refreshToken = Token(
                 userId = ID,
-                content = jwtProvider.createRefreshToken(JWT_AUTHENTICATION)
+                content = jwtProvider.createRefreshToken(createJwtAuthentication())
             ).also { tokenRepository.save(it) }
 
 
@@ -64,7 +67,7 @@ class TokenRepositoryTest : ExpectSpec() {
         context("리프레쉬 토큰 삭제") {
             Token(
                 userId = ID,
-                content = jwtProvider.createRefreshToken(JWT_AUTHENTICATION)
+                content = jwtProvider.createRefreshToken(createJwtAuthentication())
             ).let { tokenRepository.save(it) }
 
             expect("특정 유저의 리프레쉬 토큰을 삭제한다.") {

--- a/src/test/kotlin/com/youquiz/authentication/repository/TokenRepositoryTest.kt
+++ b/src/test/kotlin/com/youquiz/authentication/repository/TokenRepositoryTest.kt
@@ -1,0 +1,77 @@
+package com.youquiz.authentication.repository
+
+import com.youquiz.authentication.config.RedisTestConfiguration
+import com.youquiz.authentication.domain.Token
+import com.youquiz.authentication.fixture.ID
+import com.youquiz.authentication.fixture.JWT_AUTHENTICATION
+import com.youquiz.authentication.fixture.REFRESH_TOKEN_EXPIRE
+import com.youquiz.authentication.fixture.jwtProvider
+import io.kotest.core.spec.style.ExpectSpec
+import io.kotest.core.test.TestCase
+import io.kotest.matchers.equality.shouldBeEqualToComparingFields
+import io.kotest.matchers.equality.shouldNotBeEqualToComparingFields
+import io.kotest.matchers.nulls.shouldBeNull
+import kotlinx.coroutines.reactive.awaitSingle
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.redis.core.ReactiveRedisTemplate
+import org.springframework.test.context.ContextConfiguration
+
+@ContextConfiguration(classes = [RedisTestConfiguration::class])
+class TokenRepositoryTest : ExpectSpec() {
+    @Autowired
+    private lateinit var redisTemplate: ReactiveRedisTemplate<String, String>
+
+    private val tokenRepository by lazy {
+        TokenRepository(
+            redisTemplate = redisTemplate,
+            expire = REFRESH_TOKEN_EXPIRE
+        )
+    }
+
+    override suspend fun beforeContainer(testCase: TestCase) {
+        redisTemplate.execute { it.serverCommands().flushAll() }.awaitSingle()
+    }
+
+    init {
+        context("리프레쉬 토큰 조회") {
+            val refreshToken = Token(
+                userId = ID,
+                content = jwtProvider.createRefreshToken(JWT_AUTHENTICATION)
+            ).also { tokenRepository.save(it) }
+
+            expect("특정 유저의 리프레쉬 토큰을 조회한다.") {
+                tokenRepository.findByUserId(ID)!! shouldBeEqualToComparingFields refreshToken
+            }
+        }
+
+        context("리프레쉬 토큰 수정") {
+            val refreshToken = Token(
+                userId = ID,
+                content = jwtProvider.createRefreshToken(JWT_AUTHENTICATION)
+            ).also { tokenRepository.save(it) }
+
+
+            expect("특정 유저의 리프레쉬 토큰을 수정한다.") {
+                Token(
+                    userId = ID,
+                    content = "test"
+                ).let { tokenRepository.save(it) }
+
+                tokenRepository.findByUserId(ID)!! shouldNotBeEqualToComparingFields refreshToken
+            }
+        }
+
+        context("리프레쉬 토큰 삭제") {
+            Token(
+                userId = ID,
+                content = jwtProvider.createRefreshToken(JWT_AUTHENTICATION)
+            ).let { tokenRepository.save(it) }
+
+            expect("특정 유저의 리프레쉬 토큰을 삭제한다.") {
+                tokenRepository.deleteByUserId(ID)
+
+                tokenRepository.findByUserId(ID).shouldBeNull()
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/youquiz/authentication/service/AuthenticationServiceTest.kt
+++ b/src/test/kotlin/com/youquiz/authentication/service/AuthenticationServiceTest.kt
@@ -29,14 +29,13 @@ class AuthenticationServiceTest : BehaviorSpec() {
 
     init {
         Given("해당 아이디를 가진 유저가 존재하고 비밀번호가 일치하는 경우") {
-            val user = USER
-            val password = PASSWORD
+            val user = createUser()
 
             coEvery { userClient.findByUsername(any()) } returns user
 
             When("로그인을 시도하면") {
                 val loginResponse =
-                    authenticationService.login(LoginRequest(username = user.username, password = password))
+                    authenticationService.login(LoginRequest(username = user.username, password = PASSWORD))
 
                 Then("해당 유저에 대한 액세스 토큰과 리프레쉬 토큰이 발급된다.") {
                     jwtProvider.getAuthentication(loginResponse.accessToken).id shouldBe user.id
@@ -46,36 +45,33 @@ class AuthenticationServiceTest : BehaviorSpec() {
         }
 
         Given("해당 아이디를 가진 유저가 존재하지만 비밀번호가 일치하지 않는 경우") {
-            val user = USER
-            val invalidPassword = INVALID_PASSWORD
+            val user = createUser()
 
             coEvery { userClient.findByUsername(any()) } returns user
 
             When("로그인을 시도하면") {
                 Then("예외가 발생한다.") {
                     shouldThrow<PasswordNotMatchException> {
-                        authenticationService.login(LoginRequest(username = user.username, password = invalidPassword))
+                        authenticationService.login(LoginRequest(username = user.username, password = INVALID_PASSWORD))
                     }
                 }
             }
         }
 
         Given("해당 아이디를 가진 유저가 존재하지 않는 경우") {
-            val invalidUsername = INVALID_USERNAME
-
             coEvery { userClient.findByUsername(any()) } throws UserNotFoundException()
 
             When("로그인을 시도하면") {
                 Then("예외가 발생한다.") {
                     shouldThrow<UserNotFoundException> {
-                        authenticationService.login(LoginRequest(username = invalidUsername, password = PASSWORD))
+                        authenticationService.login(LoginRequest(username = INVALID_USERNAME, password = PASSWORD))
                     }
                 }
             }
         }
 
         Given("유저가 로그인 상태인 경우") {
-            val user = USER
+            val user = createUser()
 
             coEvery { tokenRepository.deleteByUserId(any()) } returns true
 

--- a/src/test/kotlin/com/youquiz/authentication/util/TestUtil.kt
+++ b/src/test/kotlin/com/youquiz/authentication/util/TestUtil.kt
@@ -1,6 +1,6 @@
 package com.youquiz.authentication.util
 
-import com.youquiz.authentication.fixture.JWT_AUTHENTICATION
+import com.youquiz.authentication.fixture.createJwtAuthentication
 import org.springframework.restdocs.payload.FieldDescriptor
 import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
 import org.springframework.restdocs.request.ParameterDescriptor
@@ -14,7 +14,7 @@ infix fun String.paramDesc(description: String): ParameterDescriptor =
     parameterWithName(this).description(description)
 
 fun withMockUser() {
-    SecurityContextHolder.getContext().authentication = JWT_AUTHENTICATION
+    SecurityContextHolder.getContext().authentication = createJwtAuthentication()
 }
 
 val errorResponseFields = listOf(


### PR DESCRIPTION
## 작업 내용

* **In-memory DB에서 리프레쉬 토큰을 삭제해주는 logout 기능 구현**
* **Redis 의존성 추가**

## 코멘트

* In-memory DB에 저장되는 토큰의 유효기간은 프로퍼티에 정의한 리프레쉬 토큰의 유효기간(jwt.refreshTokenExpire)과 동일.

## 관련 이슈

* **Close #3**