### PR TITLE
[YOUQ-71] 로그인 유지를 위한 token refresh API 구현

### DIFF
--- a/src/main/kotlin/com/youquiz/authentication/dto/RefreshRequest.kt
+++ b/src/main/kotlin/com/youquiz/authentication/dto/RefreshRequest.kt
@@ -1,0 +1,6 @@
+package com.youquiz.authentication.dto
+
+data class RefreshRequest(
+    val userId: Long,
+    val refreshToken: String
+)

--- a/src/main/kotlin/com/youquiz/authentication/dto/RefreshResponse.kt
+++ b/src/main/kotlin/com/youquiz/authentication/dto/RefreshResponse.kt
@@ -1,0 +1,6 @@
+package com.youquiz.authentication.dto
+
+data class RefreshResponse(
+    val accessToken: String,
+    val refreshToken: String
+)

--- a/src/main/kotlin/com/youquiz/authentication/exception/InvalidAccessException.kt
+++ b/src/main/kotlin/com/youquiz/authentication/exception/InvalidAccessException.kt
@@ -1,0 +1,7 @@
+package com.youquiz.authentication.exception
+
+import com.youquiz.authentication.global.exception.ServerException
+
+class InvalidAccessException(
+    override val message: String = "유효하지 않은 접근입니다."
+) : ServerException(code = 403, message)

--- a/src/main/kotlin/com/youquiz/authentication/exception/TokenNotFoundException.kt
+++ b/src/main/kotlin/com/youquiz/authentication/exception/TokenNotFoundException.kt
@@ -1,0 +1,7 @@
+package com.youquiz.authentication.exception
+
+import com.youquiz.authentication.global.exception.ServerException
+
+class TokenNotFoundException(
+    override val message: String = "토큰을 찾을 수 없습니다."
+) : ServerException(code = 404, message)

--- a/src/main/kotlin/com/youquiz/authentication/handler/AuthenticationHandler.kt
+++ b/src/main/kotlin/com/youquiz/authentication/handler/AuthenticationHandler.kt
@@ -2,6 +2,7 @@ package com.youquiz.authentication.handler
 
 import com.github.jwt.authentication.JwtAuthentication
 import com.youquiz.authentication.dto.LoginRequest
+import com.youquiz.authentication.dto.RefreshRequest
 import com.youquiz.authentication.service.AuthenticationService
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.server.*
@@ -19,5 +20,10 @@ class AuthenticationHandler(
         with(request.awaitPrincipal() as JwtAuthentication) {
             authenticationService.logout(id)
             ServerResponse.ok().buildAndAwait()
+        }
+
+    suspend fun refresh(request: ServerRequest): ServerResponse =
+        request.awaitBody<RefreshRequest>().let {
+            ServerResponse.ok().bodyValueAndAwait(authenticationService.refresh(it))
         }
 }

--- a/src/main/kotlin/com/youquiz/authentication/handler/AuthenticationHandler.kt
+++ b/src/main/kotlin/com/youquiz/authentication/handler/AuthenticationHandler.kt
@@ -10,8 +10,8 @@ import org.springframework.web.reactive.function.server.*
 class AuthenticationHandler(
     private val authenticationService: AuthenticationService
 ) {
-    suspend fun login(serverRequest: ServerRequest): ServerResponse =
-        serverRequest.awaitBody<LoginRequest>().let {
+    suspend fun login(request: ServerRequest): ServerResponse =
+        request.awaitBody<LoginRequest>().let {
             ServerResponse.ok().bodyValueAndAwait(authenticationService.login(it))
         }
 

--- a/src/main/kotlin/com/youquiz/authentication/repository/TokenRepository.kt
+++ b/src/main/kotlin/com/youquiz/authentication/repository/TokenRepository.kt
@@ -26,11 +26,9 @@ class TokenRepository(
 
     suspend fun save(token: Token): Boolean =
         with(token) {
-            redisTemplate.run {
-                val key = getKey(userId)
-
-                opsForValue().set(key, content, Duration.ofMinutes(expire)).awaitSingle()
-            }
+            redisTemplate.opsForValue()
+                .set(getKey(userId), content, Duration.ofMinutes(expire))
+                .awaitSingle()
         }
 
     suspend fun deleteByUserId(userId: Long): Boolean =

--- a/src/main/kotlin/com/youquiz/authentication/router/AuthenticationRouter.kt
+++ b/src/main/kotlin/com/youquiz/authentication/router/AuthenticationRouter.kt
@@ -15,6 +15,7 @@ class AuthenticationRouter {
             "/auth".nest {
                 POST("/login", handler::login)
                 GET("/logout", handler::logout)
+                POST("/refresh", handler::refresh)
             }
         }
 }

--- a/src/main/kotlin/com/youquiz/authentication/service/AuthenticationService.kt
+++ b/src/main/kotlin/com/youquiz/authentication/service/AuthenticationService.kt
@@ -18,10 +18,10 @@ class AuthenticationService(
     private val jwtProvider: JwtProvider,
     private val passwordEncoder: PasswordEncoder
 ) {
-    suspend fun login(loginRequest: LoginRequest): LoginResponse {
-        val user = userClient.findByUsername(loginRequest.username)
+    suspend fun login(request: LoginRequest): LoginResponse {
+        val user = userClient.findByUsername(request.username)
 
-        if (passwordEncoder.matches(loginRequest.password, user.password)) {
+        if (passwordEncoder.matches(request.password, user.password)) {
             val authentication = user.run {
                 DefaultJwtAuthentication(id = id, authorities = listOf(SimpleGrantedAuthority(role.name)))
             }

--- a/src/main/kotlin/com/youquiz/authentication/service/AuthenticationService.kt
+++ b/src/main/kotlin/com/youquiz/authentication/service/AuthenticationService.kt
@@ -3,9 +3,14 @@ package com.youquiz.authentication.service
 import com.github.jwt.authentication.DefaultJwtAuthentication
 import com.github.jwt.core.JwtProvider
 import com.youquiz.authentication.adapter.client.UserClient
+import com.youquiz.authentication.domain.Token
 import com.youquiz.authentication.dto.LoginRequest
 import com.youquiz.authentication.dto.LoginResponse
+import com.youquiz.authentication.dto.RefreshRequest
+import com.youquiz.authentication.dto.RefreshResponse
+import com.youquiz.authentication.exception.InvalidAccessException
 import com.youquiz.authentication.exception.PasswordNotMatchException
+import com.youquiz.authentication.exception.TokenNotFoundException
 import com.youquiz.authentication.repository.TokenRepository
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.crypto.password.PasswordEncoder
@@ -34,5 +39,23 @@ class AuthenticationService(
 
     suspend fun logout(userId: Long) {
         tokenRepository.deleteByUserId(userId)
+    }
+
+    suspend fun refresh(request: RefreshRequest): RefreshResponse {
+        val refreshToken = tokenRepository.findByUserId(request.userId)?.content ?: throw TokenNotFoundException()
+
+        jwtProvider.getAuthentication(refreshToken).let {
+            if (request.refreshToken == refreshToken) {
+                val newAccessToken = jwtProvider.createAccessToken(it)
+                val newRefreshToken = jwtProvider.createRefreshToken(it)
+
+                tokenRepository.save(Token(userId = it.id, content = newRefreshToken))
+
+                return RefreshResponse(accessToken = newAccessToken, refreshToken = newRefreshToken)
+            } else {
+                tokenRepository.deleteByUserId(it.id)
+                throw InvalidAccessException()
+            }
+        }
     }
 }

--- a/src/test/kotlin/com/youquiz/authentication/controller/AuthenticationControllerTest.kt
+++ b/src/test/kotlin/com/youquiz/authentication/controller/AuthenticationControllerTest.kt
@@ -5,12 +5,13 @@ import com.ninjasquad.springmockk.MockkBean
 import com.youquiz.authentication.config.SecurityTestConfiguration
 import com.youquiz.authentication.dto.LoginRequest
 import com.youquiz.authentication.dto.LoginResponse
+import com.youquiz.authentication.dto.RefreshRequest
+import com.youquiz.authentication.dto.RefreshResponse
+import com.youquiz.authentication.exception.InvalidAccessException
 import com.youquiz.authentication.exception.PasswordNotMatchException
+import com.youquiz.authentication.exception.TokenNotFoundException
 import com.youquiz.authentication.exception.UserNotFoundException
-import com.youquiz.authentication.fixture.PASSWORD
-import com.youquiz.authentication.fixture.USERNAME
-import com.youquiz.authentication.fixture.createJwtAuthentication
-import com.youquiz.authentication.fixture.jwtProvider
+import com.youquiz.authentication.fixture.*
 import com.youquiz.authentication.global.dto.ErrorResponse
 import com.youquiz.authentication.handler.AuthenticationHandler
 import com.youquiz.authentication.router.AuthenticationRouter
@@ -38,6 +39,16 @@ class AuthenticationControllerTest : BaseControllerTest() {
     )
 
     private val loginResponse = LoginResponse(
+        accessToken = jwtProvider.createAccessToken(createJwtAuthentication()),
+        refreshToken = jwtProvider.createRefreshToken(createJwtAuthentication())
+    )
+
+    private val refreshRequest = RefreshRequest(
+        userId = ID,
+        refreshToken = jwtProvider.createRefreshToken(createJwtAuthentication())
+    )
+
+    private val refreshResponse = RefreshResponse(
         accessToken = jwtProvider.createAccessToken(createJwtAuthentication()),
         refreshToken = jwtProvider.createRefreshToken(createJwtAuthentication())
     )
@@ -159,6 +170,92 @@ class AuthenticationControllerTest : BaseControllerTest() {
                         .isUnauthorized
                         .expectBody()
                         .consumeWith(WebTestClientRestDocumentationWrapper.document("로그아웃 실패(401)"))
+                }
+            }
+        }
+
+        describe("refresh()는") {
+            context("요청을 보낸 유저가 로그인 상태인 경우") {
+                coEvery { authenticationService.refresh(any()) } returns refreshResponse
+
+                it("상태 코드 200과 refreshResponse를 반환한다.") {
+                    webClient
+                        .post()
+                        .uri("/auth/refresh")
+                        .bodyValue(refreshRequest)
+                        .exchange()
+                        .expectStatus()
+                        .isOk
+                        .expectBody(RefreshResponse::class.java)
+                        .consumeWith(
+                            WebTestClientRestDocumentationWrapper.document(
+                                "토큰 재발급 성공",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                requestFields(
+                                    "userId" desc "유저 식별자",
+                                    "refreshToken" desc "리프레쉬 토큰"
+                                ),
+                                responseFields(
+                                    "accessToken" desc "액세스 토큰",
+                                    "refreshToken" desc "리프레쉬 토큰"
+                                )
+                            )
+                        )
+                }
+            }
+
+            context("요청을 보낸 유저의 리프레쉬 토큰이 저장소에 존재하지 않는 경우") {
+                coEvery { authenticationService.refresh(any()) } throws TokenNotFoundException()
+
+                it("상태 코드 404와 에러를 반환한다.") {
+                    webClient
+                        .post()
+                        .uri("/auth/refresh")
+                        .bodyValue(refreshRequest)
+                        .exchange()
+                        .expectStatus()
+                        .isNotFound
+                        .expectBody(ErrorResponse::class.java)
+                        .consumeWith(
+                            WebTestClientRestDocumentationWrapper.document(
+                                "토큰 리프레쉬 실패(404)",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                requestFields(
+                                    "userId" desc "유저 식별자",
+                                    "refreshToken" desc "리프레쉬 토큰"
+                                ),
+                                responseFields(errorResponseFields)
+                            )
+                        )
+                }
+            }
+
+            context("요청을 보낸 유저의 리프레쉬 토큰이 저장소에 있는 리프레쉬 토큰과 일치하지 않는 경우") {
+                coEvery { authenticationService.refresh(any()) } throws InvalidAccessException()
+
+                it("상태 코드 403 에러를 반환한다.") {
+                    webClient
+                        .post()
+                        .uri("/auth/refresh")
+                        .bodyValue(refreshRequest)
+                        .exchange()
+                        .expectStatus()
+                        .isForbidden
+                        .expectBody(ErrorResponse::class.java)
+                        .consumeWith(
+                            WebTestClientRestDocumentationWrapper.document(
+                                "토큰 리프레쉬 실패(403)",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                requestFields(
+                                    "userId" desc "유저 식별자",
+                                    "refreshToken" desc "리프레쉬 토큰"
+                                ),
+                                responseFields(errorResponseFields)
+                            )
+                        )
                 }
             }
         }

--- a/src/test/kotlin/com/youquiz/authentication/controller/AuthenticationControllerTest.kt
+++ b/src/test/kotlin/com/youquiz/authentication/controller/AuthenticationControllerTest.kt
@@ -38,6 +38,11 @@ class AuthenticationControllerTest : BaseControllerTest() {
         password = PASSWORD
     )
 
+    private val loginRequestFields = listOf(
+        "username" desc "아이디",
+        "password" desc "패스워드"
+    )
+
     private val loginResponse = LoginResponse(
         accessToken = jwtProvider.createAccessToken(createJwtAuthentication()),
         refreshToken = jwtProvider.createRefreshToken(createJwtAuthentication())
@@ -51,6 +56,21 @@ class AuthenticationControllerTest : BaseControllerTest() {
     private val refreshResponse = RefreshResponse(
         accessToken = jwtProvider.createAccessToken(createJwtAuthentication()),
         refreshToken = jwtProvider.createRefreshToken(createJwtAuthentication())
+    )
+
+    private val loginResponseFields = listOf(
+        "accessToken" desc "액세스 토큰",
+        "refreshToken" desc "리프레쉬 토큰"
+    )
+
+    private val refreshRequestFields = listOf(
+        "userId" desc "유저 식별자",
+        "refreshToken" desc "리프레쉬 토큰"
+    )
+
+    private val refreshResponseFields = listOf(
+        "accessToken" desc "액세스 토큰",
+        "refreshToken" desc "리프레쉬 토큰"
     )
 
     init {
@@ -69,17 +89,11 @@ class AuthenticationControllerTest : BaseControllerTest() {
                         .expectBody(LoginResponse::class.java)
                         .consumeWith(
                             WebTestClientRestDocumentationWrapper.document(
-                                "로그인 성공",
+                                "로그인 성공(200)",
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
-                                requestFields(
-                                    "username" desc "아이디",
-                                    "password" desc "패스워드"
-                                ),
-                                responseFields(
-                                    "accessToken" desc "액세스 토큰",
-                                    "refreshToken" desc "리프레쉬 토큰"
-                                )
+                                requestFields(loginRequestFields),
+                                responseFields(loginResponseFields)
                             )
                         )
                 }
@@ -102,10 +116,7 @@ class AuthenticationControllerTest : BaseControllerTest() {
                                 "로그인 실패(400)",
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
-                                requestFields(
-                                    "username" desc "아이디",
-                                    "password" desc "패스워드"
-                                ),
+                                requestFields(loginRequestFields),
                                 responseFields(errorResponseFields)
                             )
                         )
@@ -129,10 +140,7 @@ class AuthenticationControllerTest : BaseControllerTest() {
                                 "로그인 실패(404)",
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
-                                requestFields(
-                                    "username" desc "아이디",
-                                    "password" desc "패스워드"
-                                ),
+                                requestFields(loginRequestFields),
                                 responseFields(errorResponseFields)
                             )
                         )
@@ -189,17 +197,11 @@ class AuthenticationControllerTest : BaseControllerTest() {
                         .expectBody(RefreshResponse::class.java)
                         .consumeWith(
                             WebTestClientRestDocumentationWrapper.document(
-                                "토큰 재발급 성공",
+                                "토큰 재발급 성공(200)",
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
-                                requestFields(
-                                    "userId" desc "유저 식별자",
-                                    "refreshToken" desc "리프레쉬 토큰"
-                                ),
-                                responseFields(
-                                    "accessToken" desc "액세스 토큰",
-                                    "refreshToken" desc "리프레쉬 토큰"
-                                )
+                                requestFields(refreshRequestFields),
+                                responseFields(refreshResponseFields)
                             )
                         )
                 }
@@ -222,10 +224,7 @@ class AuthenticationControllerTest : BaseControllerTest() {
                                 "토큰 리프레쉬 실패(404)",
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
-                                requestFields(
-                                    "userId" desc "유저 식별자",
-                                    "refreshToken" desc "리프레쉬 토큰"
-                                ),
+                                requestFields(refreshRequestFields),
                                 responseFields(errorResponseFields)
                             )
                         )
@@ -235,7 +234,7 @@ class AuthenticationControllerTest : BaseControllerTest() {
             context("요청을 보낸 유저의 리프레쉬 토큰이 저장소에 있는 리프레쉬 토큰과 일치하지 않는 경우") {
                 coEvery { authenticationService.refresh(any()) } throws InvalidAccessException()
 
-                it("상태 코드 403 에러를 반환한다.") {
+                it("상태 코드 403과 에러를 반환한다.") {
                     webClient
                         .post()
                         .uri("/auth/refresh")
@@ -249,10 +248,7 @@ class AuthenticationControllerTest : BaseControllerTest() {
                                 "토큰 리프레쉬 실패(403)",
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
-                                requestFields(
-                                    "userId" desc "유저 식별자",
-                                    "refreshToken" desc "리프레쉬 토큰"
-                                ),
+                                requestFields(refreshRequestFields),
                                 responseFields(errorResponseFields)
                             )
                         )

--- a/src/test/kotlin/com/youquiz/authentication/service/AuthenticationServiceTest.kt
+++ b/src/test/kotlin/com/youquiz/authentication/service/AuthenticationServiceTest.kt
@@ -32,9 +32,9 @@ class AuthenticationServiceTest : BehaviorSpec() {
 
     init {
         Given("해당 아이디를 가진 유저가 존재하고 비밀번호가 일치하는 경우") {
-            val user = createUser()
-
-            coEvery { userClient.findByUsername(any()) } returns user
+            val user = createUser().also {
+                coEvery { userClient.findByUsername(any()) } returns it
+            }
 
             When("로그인을 시도하면") {
                 val loginResponse =
@@ -48,9 +48,9 @@ class AuthenticationServiceTest : BehaviorSpec() {
         }
 
         Given("해당 아이디를 가진 유저가 존재하지만 비밀번호가 일치하지 않는 경우") {
-            val user = createUser()
-
-            coEvery { userClient.findByUsername(any()) } returns user
+            val user = createUser().also {
+                coEvery { userClient.findByUsername(any()) } returns it
+            }
 
             When("로그인을 시도하면") {
                 Then("예외가 발생한다.") {


### PR DESCRIPTION
## 작업 내용

* **로그인 유지 기능 구현 및 테스트**

## 코멘트

* 리프레쉬 토큰을 통해 로그인 유지를 시도할 때마다 액세스 토큰 뿐만 아니라 리프레쉬 토큰도 재발급하는 Refresh token rotation 적용.
* 악의적인 접근으로 간주되는 요청(리프레쉬 토큰이 저장소 존재하지만 일치하지 않는 등의 요청)들이 감지되면 해당 유저에 대한 리프레쉬 토큰을 저장소에서 삭제하도록 구현.

## 관련 이슈

* **Close #4**