### PR TITLE
[YOUQ-98] 로그인 API에 리프레쉬 토큰 저장 로직 추가

### DIFF
--- a/src/main/kotlin/com/youquiz/authentication/service/AuthenticationService.kt
+++ b/src/main/kotlin/com/youquiz/authentication/service/AuthenticationService.kt
@@ -36,6 +36,13 @@ class AuthenticationService(
                 val accessToken = jwtProvider.createAccessToken(it)
                 val refreshToken = jwtProvider.createRefreshToken(it)
 
+                tokenRepository.save(
+                    Token(
+                        userId = it.id,
+                        content = refreshToken
+                    )
+                )
+
                 return LoginResponse(accessToken = accessToken, refreshToken = refreshToken)
             }
         } else throw PasswordNotMatchException()

--- a/src/test/kotlin/com/youquiz/authentication/service/AuthenticationServiceTest.kt
+++ b/src/test/kotlin/com/youquiz/authentication/service/AuthenticationServiceTest.kt
@@ -57,7 +57,12 @@ class AuthenticationServiceTest : BehaviorSpec() {
             When("로그인을 시도하면") {
                 Then("예외가 발생한다.") {
                     shouldThrow<PasswordNotMatchException> {
-                        authenticationService.login(LoginRequest(username = user.username, password = INVALID_PASSWORD))
+                        authenticationService.login(
+                            LoginRequest(
+                                username = user.username,
+                                password = INVALID_PASSWORD
+                            )
+                        )
                     }
                 }
             }
@@ -70,7 +75,12 @@ class AuthenticationServiceTest : BehaviorSpec() {
             When("로그인을 시도하면") {
                 Then("예외가 발생한다.") {
                     shouldThrow<UserNotFoundException> {
-                        authenticationService.login(LoginRequest(username = INVALID_USERNAME, password = PASSWORD))
+                        authenticationService.login(
+                            LoginRequest(
+                                username = INVALID_USERNAME,
+                                password = PASSWORD
+                            )
+                        )
                     }
                 }
             }

--- a/src/test/kotlin/com/youquiz/authentication/service/AuthenticationServiceTest.kt
+++ b/src/test/kotlin/com/youquiz/authentication/service/AuthenticationServiceTest.kt
@@ -34,6 +34,7 @@ class AuthenticationServiceTest : BehaviorSpec() {
         Given("해당 아이디를 가진 유저가 존재하고 비밀번호가 일치하는 경우") {
             val user = createUser().also {
                 coEvery { userClient.findByUsername(any()) } returns it
+                coEvery { tokenRepository.save(any()) } returns true
             }
 
             When("로그인을 시도하면") {
@@ -50,6 +51,7 @@ class AuthenticationServiceTest : BehaviorSpec() {
         Given("해당 아이디를 가진 유저가 존재하지만 비밀번호가 일치하지 않는 경우") {
             val user = createUser().also {
                 coEvery { userClient.findByUsername(any()) } returns it
+                coEvery { tokenRepository.save(any()) } returns false
             }
 
             When("로그인을 시도하면") {
@@ -63,6 +65,7 @@ class AuthenticationServiceTest : BehaviorSpec() {
 
         Given("해당 아이디를 가진 유저가 존재하지 않는 경우") {
             coEvery { userClient.findByUsername(any()) } throws UserNotFoundException()
+            coEvery { tokenRepository.save(any()) } returns false
 
             When("로그인을 시도하면") {
                 Then("예외가 발생한다.") {


### PR DESCRIPTION
## 작업 내용

* **로그인 로직 내에 토큰 저장 로직 추가**

## 코멘트

* 로그인 시 주어지는 리프레쉬 토큰으로 로그인 유지가 불가능했던 버그 수정

## 관련 이슈

* **Close #8**