### PR TITLE
[#13] DAO 계층 테스트 외부 의존성 분리

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,6 +52,7 @@ dependencies {
     testImplementation("com.ninja-squad:springmockk:3.0.1")
     testImplementation("com.epages:restdocs-api-spec-webtestclient:0.17.1")
     testImplementation("com.epages:restdocs-api-spec:0.17.1")
+    testImplementation("it.ozimov:embedded-redis:0.7.2")
 }
 
 tasks {

--- a/src/test/kotlin/com/quizit/authentication/config/RedisTestConfiguration.kt
+++ b/src/test/kotlin/com/quizit/authentication/config/RedisTestConfiguration.kt
@@ -1,17 +1,32 @@
 package com.quizit.authentication.config
 
+import jakarta.annotation.PostConstruct
+import jakarta.annotation.PreDestroy
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
 import org.springframework.data.redis.core.ReactiveRedisTemplate
 import org.springframework.data.redis.serializer.RedisSerializationContext
+import redis.embedded.RedisServer
 
 @TestConfiguration
 class RedisTestConfiguration {
+    private val redisServer: RedisServer by lazy { RedisServer(6380) }
+
+    @PostConstruct
+    fun startRedis() {
+        redisServer.start()
+    }
+
+    @PreDestroy
+    fun stopRedis() {
+        redisServer.stop()
+    }
+
     @Bean
     fun redisConnectionFactory(): LettuceConnectionFactory =
-        LettuceConnectionFactory(RedisStandaloneConfiguration("localhost", 6379))
+        LettuceConnectionFactory(RedisStandaloneConfiguration("localhost", 6380))
 
     @Bean
     fun reactiveRedisTemplate(): ReactiveRedisTemplate<String, String> =


### PR DESCRIPTION
## 작업 내용

* **테스트 환경에서의 Embedded Redis 설정**

## 코멘트

* Embedded Redis는 정적으로 6380 포트를 사용하도록 설정

## 관련 이슈

* **Close #13**