### PR TITLE
[YOUQ-123] Jenkins CI 연동

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM amazoncorretto:17
+COPY ./*.jar app.jar
+ENTRYPOINT ["java", "-jar", "-Dspring.profiles.active=dev", "app.jar"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,67 @@
+pipeline{
+    agent {
+        kubernetes{
+            yaml '''
+               apiVersoin: v1
+               kind: Pod
+               spec:
+                 serviceAccountName: jenkins
+                 containers:
+                 - name: aws
+                   image: amazon/aws-cli
+                   command:
+                   - sleep
+                   args:
+                   - infinity
+                 - name: gradle
+                   image: gradle:8.1.1
+                   command: ['sleep']
+                   args: ['infinity']
+                 - name: kaniko
+                   image: gcr.io/kaniko-project/executor:debug
+                   command:
+                   - sleep
+                   args:
+                   - infinity
+                   env:
+                   - name: AWS_SDK_LOAD_CONFIG
+                     value: true
+            '''
+        }
+    }
+    stages{
+        stage('Git Clone'){
+            steps{
+                git url: 'https://github.com/SWM-YouQuiz/Authentication-Service.git',
+                    branch: 'dev',
+                    credentialsId: "github_personal_access_token"
+            }
+        }
+        stage('Gradle Build'){
+            steps{
+                container('gradle'){
+                    sh 'mkdir ./src/main/resources/static'
+                    sh 'mkdir ./src/main/resources/static/docs'
+
+                    sh 'gradle build'
+
+                    sh 'mv ./build/libs/auth-service.jar ./'
+                }
+            }
+        }
+        stage('aws'){
+            steps{
+                container('aws'){
+                    sh "aws s3 cp src/main/resources/static/docs/api.yml s3://quizit-swagger/auth.yml"
+                }
+            }
+        }
+        stage('Docker Build'){
+            steps{
+                container('kaniko'){
+                    sh "executor --dockerfile=Dockerfile --context=dir://${env.WORKSPACE} --destination=${env.ECR_AUTH_SERVICE}:latest"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 작업 내용

* **각 레포별로 dev 브랜치로 Merge 됐을경우, Jenkins 서버에 Webhook을 보내도록 설정했습니다.**
* **Jenkins 서버에 작성된 서비스별 Job은 해당 Webhook을 Trigger로 정하고 있습니다.**
* **빌드 결과물로 생기는 OAS yaml 파일을 s3에 자동으로 업데이트합니다.**
* **Swagger 서버는 실시간으로 바뀐 OAS yaml 파일을 가져옵니다.**
* **보안을 위해 DinD, DooD 방식이 아닌 kaniko를 통해 이미지를 빌드합니다.**
* **보안을 위해 직접적인 AWS Credential 및 Node Role을 사용하지 않고, IRSA를 통해 Pod 범위의 권한을 설정했습니다.**
* **보안을 위해 ECR 주소나 Github Token은 Jenkins 내의 Credential과 환경변수로 관리했습니다.**

## 코멘트

* Jenkins Agent는 항상 구동되는것이 아닌 Job을 실행할때만 Pod를 생성합니다.
* 가독성을 고려해 Jenkins pipeline의 stage를 나누었습니다.
* Git Clone부터 ECR에 적재되기까지 평균 4분정도 소요됩니다.
* ECR에는 최근 30개 까지의 이미지만 적재됩니다.
* EC2와의 호환성을 고려하여 Dockerfile의 Base 이미지로 amazoncorretto를 사용했습니다.

## 관련 이슈

* **Close #15**