### PR TITLE
[#17] 모든 API 엔드포인트 prefix 수정

### DIFF
--- a/src/main/kotlin/com/quizit/authentication/global/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/com/quizit/authentication/global/config/SecurityConfiguration.kt
@@ -30,10 +30,8 @@ class SecurityConfiguration {
             httpBasic { it.authenticationEntryPoint(HttpStatusServerEntryPoint(HttpStatus.UNAUTHORIZED)) }
             securityContextRepository(NoOpServerSecurityContextRepository.getInstance())
             authorizeExchange {
-                it.pathMatchers("/api/admin/**")
+                it.pathMatchers("/api/auth/admin/**")
                     .hasAuthority("ADMIN")
-                    .pathMatchers("/api/auth/logout")
-                    .authenticated()
                     .anyExchange()
                     .permitAll()
             }

--- a/src/main/kotlin/com/quizit/authentication/router/AuthenticationRouter.kt
+++ b/src/main/kotlin/com/quizit/authentication/router/AuthenticationRouter.kt
@@ -12,7 +12,7 @@ class AuthenticationRouter {
     @Bean
     fun authenticationRoutes(handler: AuthenticationHandler): RouterFunction<ServerResponse> =
         coRouter {
-            "/api/auth".nest {
+            "/auth".nest {
                 GET("/logout", handler::logout)
                 POST("/login", handler::login)
                 POST("/refresh", handler::refresh)

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,4 +1,6 @@
 spring:
+  webflux:
+    base-path: /api/auth
   data:
     redis:
       host: ${REDIS_HOST}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,6 +1,8 @@
 server:
   port: 8081
 spring:
+  webflux:
+    base-path: /api/auth
   data:
     redis:
       host: localhost

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,6 +1,6 @@
 spring:
   webflux:
-    base-path: /api/quiz
+    base-path: /api/auth
   data:
     redis:
       host: ${REDIS_HOST}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,4 +1,6 @@
 spring:
+  webflux:
+    base-path: /api/quiz
   data:
     redis:
       host: ${REDIS_HOST}

--- a/src/test/kotlin/com/quizit/authentication/controller/AuthenticationControllerTest.kt
+++ b/src/test/kotlin/com/quizit/authentication/controller/AuthenticationControllerTest.kt
@@ -147,21 +147,6 @@ class AuthenticationControllerTest : BaseControllerTest() {
                         .consumeWith(WebTestClientRestDocumentationWrapper.document("로그아웃 성공(200)"))
                 }
             }
-
-            context("요청을 보낸 유저가 로그인 상태가 아닌 경우") {
-                coEvery { authenticationService.logout(any()) } just Runs
-
-                it("상태 코드 401을 반환한다.") {
-                    webClient
-                        .get()
-                        .uri("/auth/logout")
-                        .exchange()
-                        .expectStatus()
-                        .isUnauthorized
-                        .expectBody()
-                        .consumeWith(WebTestClientRestDocumentationWrapper.document("로그아웃 실패(401)"))
-                }
-            }
         }
 
         describe("refresh()는") {

--- a/src/test/kotlin/com/quizit/authentication/util/BaseControllerTest.kt
+++ b/src/test/kotlin/com/quizit/authentication/util/BaseControllerTest.kt
@@ -25,7 +25,6 @@ abstract class BaseControllerTest : DescribeSpec() {
     override suspend fun beforeSpec(spec: Spec) {
         webClient = WebTestClient.bindToApplicationContext(applicationContext)
             .configureClient()
-            .baseUrl("/api")
             .filter(WebTestClientRestDocumentation.documentationConfiguration(restDocumentation))
             .build()
     }


### PR DESCRIPTION
## 작업 내용

* **모든 API 엔드포인트가 /api/auth를 prefix로 가지도록 설정**

## 코멘트
* 다른 서비스들과 마찬가지로 401(Unauthorized)에 대한 컨트롤러 계층 테스트는 삭제

## 관련 이슈

* **Close #17**