### PR TITLE
Fix: WebClient Endpoint 수정

### DIFF
--- a/src/main/kotlin/com/quizit/authentication/adapter/client/UserClient.kt
+++ b/src/main/kotlin/com/quizit/authentication/adapter/client/UserClient.kt
@@ -14,7 +14,7 @@ class UserClient(
 ) {
     suspend fun getUserByUsername(username: String): com.quizit.authentication.dto.response.GetUserByUsernameResponse =
         webClient.get()
-            .uri("$url/api/user/username/{username}", username)
+            .uri("$url/api/user/user/username/{username}", username)
             .retrieve()
             .onStatus(
                 HttpStatus.NOT_FOUND::equals
@@ -25,7 +25,7 @@ class UserClient(
         username: String
     ): com.quizit.authentication.dto.response.GetPasswordByUsernameResponse =
         webClient.get()
-            .uri("$url/api/user/username/{username}/password", username)
+            .uri("$url/api/user/user/username/{username}/password", username)
             .retrieve()
             .onStatus(
                 HttpStatus.NOT_FOUND::equals


### PR DESCRIPTION
## 작업 내용

* **서비스간 통신 EndPoint 수정**

## 코멘트
* 이전 PR #18 이 이미 merge 되어서 수정 pr을 작성했습니다.
* 이전 PR Review 과정에서 WebClient간의 통신을 고려하지 못했습니다.
* {xxx-service}/api/{xxx}/*  로 URL을 통일했습니다.

> 현재 요청 흐름은 도메인/api/user/* -> alb -> user-service:80 -> user-service-deploy:8080/api/user/* 입니다

* alb ingress가 rewrite path를 지원하지 않아서 이런 번거로움이 생겼습니다.
* 만약 이후에 지원하게된다면 다음과 같이 깔끔하게 될 수 있습니다.

> 도메인/api/user/* -> alb -> user-service:80 -> user-service-deploy:8080/*

* 이렇게 된다면 WebClient에서도 user-service/* 로 바로 호출할 수 있습니다. 많이 아쉽습니다

## 관련 이슈

* **#17**