### PR TITLE
[#29] 로그인 API 응답에 유저 정보 추가

### DIFF
--- a/src/main/kotlin/com/quizit/authentication/adapter/client/UserClient.kt
+++ b/src/main/kotlin/com/quizit/authentication/adapter/client/UserClient.kt
@@ -1,8 +1,8 @@
 package com.quizit.authentication.adapter.client
 
 import com.quizit.authentication.dto.request.MatchPasswordRequest
-import com.quizit.authentication.dto.response.GetUserByUsernameResponse
 import com.quizit.authentication.dto.response.MatchPasswordResponse
+import com.quizit.authentication.dto.response.UserResponse
 import com.quizit.authentication.exception.UserNotFoundException
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
@@ -16,12 +16,12 @@ class UserClient(
     @Value("\${url.service.user}")
     private val url: String
 ) {
-    suspend fun getUserByUsername(username: String): GetUserByUsernameResponse =
+    suspend fun getUserByUsername(username: String): UserResponse =
         webClient.get()
             .uri("$url/api/user/user/username/{username}", username)
             .retrieve()
             .onStatus(HttpStatus.NOT_FOUND::equals) { throw UserNotFoundException() }
-            .awaitBody<GetUserByUsernameResponse>()
+            .awaitBody<UserResponse>()
 
     suspend fun matchPassword(username: String, request: MatchPasswordRequest): MatchPasswordResponse =
         webClient.post()

--- a/src/main/kotlin/com/quizit/authentication/domain/Role.kt
+++ b/src/main/kotlin/com/quizit/authentication/domain/Role.kt
@@ -1,6 +1,0 @@
-package com.quizit.authentication.domain
-
-enum class Role {
-    ADMIN,
-    USER
-}

--- a/src/main/kotlin/com/quizit/authentication/domain/Role.kt
+++ b/src/main/kotlin/com/quizit/authentication/domain/Role.kt
@@ -1,0 +1,6 @@
+package com.quizit.authentication.domain
+
+enum class Role {
+    ADMIN,
+    USER
+}

--- a/src/main/kotlin/com/quizit/authentication/domain/enum/Role.kt
+++ b/src/main/kotlin/com/quizit/authentication/domain/enum/Role.kt
@@ -1,0 +1,6 @@
+package com.quizit.authentication.domain.enum
+
+enum class Role {
+    ADMIN,
+    USER
+}

--- a/src/main/kotlin/com/quizit/authentication/dto/response/LoginResponse.kt
+++ b/src/main/kotlin/com/quizit/authentication/dto/response/LoginResponse.kt
@@ -2,5 +2,6 @@ package com.quizit.authentication.dto.response
 
 data class LoginResponse(
     val accessToken: String,
-    val refreshToken: String
+    val refreshToken: String,
+    val user: UserResponse
 )

--- a/src/main/kotlin/com/quizit/authentication/dto/response/UserResponse.kt
+++ b/src/main/kotlin/com/quizit/authentication/dto/response/UserResponse.kt
@@ -1,13 +1,14 @@
 package com.quizit.authentication.dto.response
 
+import com.quizit.authentication.domain.Role
 import java.time.LocalDateTime
 
-data class GetUserByUsernameResponse(
+data class UserResponse(
     val id: String,
     val username: String,
     val nickname: String,
     val image: String?,
-    val role: String,
+    val role: Role,
     val allowPush: Boolean,
     val dailyTarget: Int,
     val answerRate: Double,

--- a/src/main/kotlin/com/quizit/authentication/dto/response/UserResponse.kt
+++ b/src/main/kotlin/com/quizit/authentication/dto/response/UserResponse.kt
@@ -1,6 +1,6 @@
 package com.quizit.authentication.dto.response
 
-import com.quizit.authentication.domain.Role
+import com.quizit.authentication.domain.enum.Role
 import java.time.LocalDateTime
 
 data class UserResponse(

--- a/src/main/kotlin/com/quizit/authentication/repository/TokenRepository.kt
+++ b/src/main/kotlin/com/quizit/authentication/repository/TokenRepository.kt
@@ -18,7 +18,7 @@ class TokenRepository(
         redisTemplate.opsForValue()
             .get(getKey(userId))
             .awaitSingleOrNull()?.let {
-                com.quizit.authentication.domain.Token(
+                Token(
                     userId = userId,
                     content = it
                 )

--- a/src/test/kotlin/com/quizit/authentication/controller/AuthenticationControllerTest.kt
+++ b/src/test/kotlin/com/quizit/authentication/controller/AuthenticationControllerTest.kt
@@ -45,7 +45,19 @@ class AuthenticationControllerTest : BaseControllerTest() {
 
     private val loginResponseFields = listOf(
         "accessToken" desc "액세스 토큰",
-        "refreshToken" desc "리프레쉬 토큰"
+        "refreshToken" desc "리프레쉬 토큰",
+        "user.id" desc "유저 식별자",
+        "user.username" desc "유저 아이디",
+        "user.nickname" desc "유저 닉네임",
+        "user.image" desc "유저 프로필 사진",
+        "user.role" desc "유저 권한",
+        "user.allowPush" desc "유저 알림 여부",
+        "user.dailyTarget" desc "유저 하루 목표",
+        "user.answerRate" desc "유저 정답률",
+        "user.correctQuizIds" desc "유저가 맞은 퀴즈 리스트",
+        "user.incorrectQuizIds" desc "유저가 틀린 퀴즈 리스트",
+        "user.markedQuizIds" desc "유저가 저장한 퀴즈 리스트",
+        "user.createdDate" desc "유저 가입 날짜"
     )
 
     private val refreshResponseFields = listOf(

--- a/src/test/kotlin/com/quizit/authentication/fixture/AuthFixture.kt
+++ b/src/test/kotlin/com/quizit/authentication/fixture/AuthFixture.kt
@@ -4,6 +4,7 @@ import com.quizit.authentication.dto.request.LoginRequest
 import com.quizit.authentication.dto.request.RefreshRequest
 import com.quizit.authentication.dto.response.LoginResponse
 import com.quizit.authentication.dto.response.RefreshResponse
+import com.quizit.authentication.dto.response.UserResponse
 
 fun createLoginRequest(
     username: String = USERNAME,
@@ -16,11 +17,13 @@ fun createLoginRequest(
 
 fun createLoginResponse(
     accessToken: String = ACCESS_TOKEN,
-    refreshToken: String = REFRESH_TOKEN
+    refreshToken: String = REFRESH_TOKEN,
+    user: UserResponse = createUserResponse()
 ): LoginResponse =
     LoginResponse(
         accessToken = accessToken,
-        refreshToken = refreshToken
+        refreshToken = refreshToken,
+        user = user
     )
 
 fun createRefreshRequest(

--- a/src/test/kotlin/com/quizit/authentication/fixture/UserFixture.kt
+++ b/src/test/kotlin/com/quizit/authentication/fixture/UserFixture.kt
@@ -1,6 +1,6 @@
 package com.quizit.authentication.fixture
 
-import com.quizit.authentication.domain.Role
+import com.quizit.authentication.domain.enum.Role
 import com.quizit.authentication.dto.request.MatchPasswordRequest
 import com.quizit.authentication.dto.response.MatchPasswordResponse
 import com.quizit.authentication.dto.response.UserResponse

--- a/src/test/kotlin/com/quizit/authentication/fixture/UserFixture.kt
+++ b/src/test/kotlin/com/quizit/authentication/fixture/UserFixture.kt
@@ -1,15 +1,16 @@
 package com.quizit.authentication.fixture
 
+import com.quizit.authentication.domain.Role
 import com.quizit.authentication.dto.request.MatchPasswordRequest
-import com.quizit.authentication.dto.response.GetUserByUsernameResponse
 import com.quizit.authentication.dto.response.MatchPasswordResponse
+import com.quizit.authentication.dto.response.UserResponse
 import java.time.LocalDateTime
 
 const val USERNAME = "earlgrey02@github.com"
 const val NICKNAME = "earlgrey02"
 const val PASSWORD = "root"
 const val IMAGE = "test"
-const val ROLE = "USER"
+val ROLE = Role.USER
 const val ALLOW_PUSH = true
 const val DAILY_TARGET = 10
 const val ANSWER_RATE = 50.0
@@ -30,12 +31,12 @@ fun createMatchPasswordResponse(
 ): MatchPasswordResponse =
     MatchPasswordResponse(isMatched)
 
-fun createGetUserByUsernameResponse(
+fun createUserResponse(
     id: String = ID,
     username: String = USERNAME,
     nickname: String = NICKNAME,
     image: String = IMAGE,
-    role: String = ROLE,
+    role: Role = ROLE,
     allowPush: Boolean = ALLOW_PUSH,
     dailyTarget: Int = DAILY_TARGET,
     answerRate: Double = ANSWER_RATE,
@@ -43,8 +44,8 @@ fun createGetUserByUsernameResponse(
     correctQuizIds: Set<String> = CORRECT_QUIZ_IDS,
     incorrectQuizIds: Set<String> = INCORRECT_QUIZ_IDS,
     markedQuizIds: Set<String> = MARKED_QUIZ_IDS,
-): GetUserByUsernameResponse =
-    GetUserByUsernameResponse(
+): UserResponse =
+    UserResponse(
         id = id,
         username = username,
         nickname = nickname,

--- a/src/test/kotlin/com/quizit/authentication/service/AuthenticationServiceTest.kt
+++ b/src/test/kotlin/com/quizit/authentication/service/AuthenticationServiceTest.kt
@@ -30,7 +30,7 @@ class AuthenticationServiceTest : BehaviorSpec() {
 
     init {
         Given("해당 아이디를 가진 유저가 존재하고 비밀번호가 일치하는 경우") {
-            coEvery { userClient.getUserByUsername(any()) } returns createGetUserByUsernameResponse()
+            coEvery { userClient.getUserByUsername(any()) } returns createUserResponse()
             coEvery { userClient.matchPassword(any(), any()) } returns createMatchPasswordResponse()
             coEvery { tokenRepository.save(any()) } returns true
 
@@ -45,7 +45,7 @@ class AuthenticationServiceTest : BehaviorSpec() {
         }
 
         Given("해당 아이디를 가진 유저가 존재하지만 비밀번호가 일치하지 않는 경우") {
-            coEvery { userClient.getUserByUsername(any()) } returns createGetUserByUsernameResponse()
+            coEvery { userClient.getUserByUsername(any()) } returns createUserResponse()
             coEvery { userClient.matchPassword(any(), any()) } returns createMatchPasswordResponse(false)
             coEvery { tokenRepository.save(any()) } returns false
 
@@ -59,11 +59,7 @@ class AuthenticationServiceTest : BehaviorSpec() {
         }
 
         Given("해당 아이디를 가진 유저가 존재하지 않는 경우") {
-            coEvery {
-                userClient.getUserByUsername(
-                    any()
-                )
-            } throws UserNotFoundException()
+            coEvery { userClient.getUserByUsername(any()) } throws UserNotFoundException()
             coEvery { userClient.matchPassword(any(), any()) } throws UserNotFoundException()
             coEvery { tokenRepository.save(any()) } returns false
 


### PR DESCRIPTION
## 작업 내용

* **로그인 API의 응답에 유저 정보도 주어지도록 수정**
* **외부 서비스 통신 중 비동기 처리 과정에서 Coroutine Scope로 Dispatchers.IO를 사용하도록 수정**

## 관련 이슈

* **Close #29**