### PR TITLE
[#34] Coroutine을 Reactive Streams로 마이그레이션

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-data-redis-reactive")
     implementation("org.springframework.boot:spring-boot-starter-log4j2")
+    implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("org.jetbrains.kotlin:kotlin-reflect")

--- a/src/main/kotlin/com/quizit/authentication/adapter/client/UserClient.kt
+++ b/src/main/kotlin/com/quizit/authentication/adapter/client/UserClient.kt
@@ -8,7 +8,8 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
-import org.springframework.web.reactive.function.client.awaitBody
+import org.springframework.web.reactive.function.client.bodyToMono
+import reactor.core.publisher.Mono
 
 @Component
 class UserClient(
@@ -16,18 +17,18 @@ class UserClient(
     @Value("\${url.service.user}")
     private val url: String
 ) {
-    suspend fun getUserByUsername(username: String): UserResponse =
+    fun getUserByUsername(username: String): Mono<UserResponse> =
         webClient.get()
             .uri("$url/api/user/user/username/{username}", username)
             .retrieve()
-            .onStatus(HttpStatus.NOT_FOUND::equals) { throw UserNotFoundException() }
-            .awaitBody<UserResponse>()
+            .onStatus(HttpStatus.NOT_FOUND::equals) { Mono.error(UserNotFoundException()) }
+            .bodyToMono<UserResponse>()
 
-    suspend fun matchPassword(username: String, request: MatchPasswordRequest): MatchPasswordResponse =
+    fun matchPassword(username: String, request: MatchPasswordRequest): Mono<MatchPasswordResponse> =
         webClient.post()
             .uri("$url/api/user/user/username/{username}/match-password", username)
             .bodyValue(request)
             .retrieve()
-            .onStatus(HttpStatus.NOT_FOUND::equals) { throw UserNotFoundException() }
-            .awaitBody<MatchPasswordResponse>()
+            .onStatus(HttpStatus.NOT_FOUND::equals) { Mono.error(UserNotFoundException()) }
+            .bodyToMono<MatchPasswordResponse>()
 }

--- a/src/main/kotlin/com/quizit/authentication/domain/OAuth2UserInfo.kt
+++ b/src/main/kotlin/com/quizit/authentication/domain/OAuth2UserInfo.kt
@@ -1,0 +1,49 @@
+//package com.quizit.authentication.domain
+//
+//import com.quizit.authentication.domain.enum.Provider
+//import org.springframework.security.core.GrantedAuthority
+//import org.springframework.security.oauth2.core.oidc.OidcIdToken
+//import org.springframework.security.oauth2.core.oidc.OidcUserInfo
+//import org.springframework.security.oauth2.core.oidc.user.OidcUser
+//
+//sealed class OAuth2UserInfo(
+//    val email: String,
+//    val provider: Provider,
+//    open val attributes: Map<String, *>
+//) : OidcUser {
+//    override fun getAttributes(): Map<String, *> = attributes
+//
+//    override fun getClaims(): Map<String, *>? = null
+//
+//    override fun getUserInfo(): OidcUserInfo? = null
+//
+//    override fun getIdToken(): OidcIdToken? = null
+//
+//    override fun getName(): String? = null
+//
+//    override fun getAuthorities(): List<GrantedAuthority>? = null
+//}
+//
+//class GoogleOAuth2UserInfo(
+//    override val attributes: Map<String, *>
+//) : OAuth2UserInfo(
+//    email = attributes["email"] as String,
+//    provider = Provider.GOOGLE,
+//    attributes = attributes
+//)
+//
+//class KakaoOAuth2UserInfo(
+//    override val attributes: Map<String, *>
+//) : OAuth2UserInfo(
+//    email = (attributes["properties"] as Map<*, *>)["email"] as String,
+//    provider = Provider.KAKAO,
+//    attributes = attributes
+//)
+//
+//class AppleOAuth2UserInfo(
+//    override val attributes: Map<String, *>
+//) : OAuth2UserInfo(
+//    email = (attributes["response"] as Map<*, *>)["email"] as String,
+//    provider = Provider.APPLE,
+//    attributes = attributes
+//)

--- a/src/main/kotlin/com/quizit/authentication/domain/Token.kt
+++ b/src/main/kotlin/com/quizit/authentication/domain/Token.kt
@@ -1,6 +1,9 @@
 package com.quizit.authentication.domain
 
-data class Token(
+import org.springframework.data.redis.core.RedisHash
+
+@RedisHash
+class Token(
     val userId: String,
     val content: String
 )

--- a/src/main/kotlin/com/quizit/authentication/domain/enum/Provider.kt
+++ b/src/main/kotlin/com/quizit/authentication/domain/enum/Provider.kt
@@ -1,0 +1,7 @@
+//package com.quizit.authentication.domain.enum
+//
+//enum class Provider {
+//    GOOGLE,
+//    APPLE,
+//    KAKAO
+//}

--- a/src/main/kotlin/com/quizit/authentication/dto/response/UserResponse.kt
+++ b/src/main/kotlin/com/quizit/authentication/dto/response/UserResponse.kt
@@ -7,14 +7,14 @@ data class UserResponse(
     val id: String,
     val username: String,
     val nickname: String,
-    val image: String?,
+    val image: String,
     val level: Int,
     val role: Role,
     val allowPush: Boolean,
     val dailyTarget: Int,
     val answerRate: Double,
-    val createdDate: LocalDateTime,
-    val correctQuizIds: Set<String>,
-    val incorrectQuizIds: Set<String>,
-    val markedQuizIds: Set<String>
+    val correctQuizIds: HashSet<String>,
+    val incorrectQuizIds: HashSet<String>,
+    val markedQuizIds: HashSet<String>,
+    val createdDate: LocalDateTime
 )

--- a/src/main/kotlin/com/quizit/authentication/global/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/com/quizit/authentication/global/config/SecurityConfiguration.kt
@@ -3,6 +3,7 @@ package com.quizit.authentication.global.config
 import com.github.jwt.authentication.DefaultJwtAuthentication
 import com.github.jwt.authentication.JwtAuthenticationFilter
 import com.github.jwt.core.JwtProvider
+import com.quizit.authentication.domain.enum.Role
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpStatus
@@ -31,7 +32,7 @@ class SecurityConfiguration {
             securityContextRepository(NoOpServerSecurityContextRepository.getInstance())
             authorizeExchange {
                 it.pathMatchers("/api/auth/admin/**")
-                    .hasAuthority("ADMIN")
+                    .hasAuthority(Role.ADMIN.name)
                     .pathMatchers(
                         "/actuator/health/**",
                         "/auth/login"

--- a/src/main/kotlin/com/quizit/authentication/global/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/quizit/authentication/global/exception/GlobalExceptionHandler.kt
@@ -3,8 +3,6 @@ package com.quizit.authentication.global.exception
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.quizit.authentication.global.dto.ErrorResponse
 import com.quizit.authentication.global.util.logger
-import kotlinx.coroutines.reactor.awaitSingleOrNull
-import kotlinx.coroutines.reactor.mono
 import org.springframework.boot.web.reactive.error.ErrorWebExceptionHandler
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpStatusCode
@@ -17,20 +15,23 @@ import reactor.kotlin.core.publisher.toMono
 class GlobalExceptionHandler(
     private val objectMapper: ObjectMapper
 ) : ErrorWebExceptionHandler {
-    override fun handle(exchange: ServerWebExchange, ex: Throwable): Mono<Void> = mono {
-        logger.error { "${ex.message} at ${ex.stackTrace[0]}" }
-
-        val errorResponse = if (ex is ServerException) {
-            ErrorResponse(code = ex.code, message = ex.message)
-        } else {
-            ErrorResponse(code = 500, message = "Internal Server Error")
-        }
-
+    override fun handle(exchange: ServerWebExchange, ex: Throwable): Mono<Void> =
         with(exchange.response) {
+            val errorResponse = if (ex is ServerException) {
+                ErrorResponse(code = ex.code, message = ex.message)
+            } else {
+                ErrorResponse(code = 500, message = "Internal Server Error")
+            }
+
+            logger.error { "${ex.message} at ${ex.stackTrace[0]}" }
+
             statusCode = HttpStatusCode.valueOf(errorResponse.code)
             headers.contentType = MediaType.APPLICATION_JSON
 
-            writeWith(bufferFactory().wrap(objectMapper.writeValueAsBytes(errorResponse)).toMono()).awaitSingleOrNull()
+            writeWith(
+                bufferFactory()
+                    .wrap(objectMapper.writeValueAsBytes(errorResponse))
+                    .toMono()
+            )
         }
-    }
 }

--- a/src/main/kotlin/com/quizit/authentication/global/util/KotlinUtil.kt
+++ b/src/main/kotlin/com/quizit/authentication/global/util/KotlinUtil.kt
@@ -1,0 +1,7 @@
+package com.quizit.authentication.global.util
+
+import reactor.util.function.Tuple2
+
+operator fun <T1, T2> Tuple2<T1, T2>.component1(): T1 = t1
+
+operator fun <T1, T2> Tuple2<T1, T2>.component2(): T2 = t2

--- a/src/main/kotlin/com/quizit/authentication/handler/AuthenticationHandler.kt
+++ b/src/main/kotlin/com/quizit/authentication/handler/AuthenticationHandler.kt
@@ -2,29 +2,37 @@ package com.quizit.authentication.handler
 
 import com.quizit.authentication.dto.request.LoginRequest
 import com.quizit.authentication.dto.request.RefreshRequest
-import com.quizit.authentication.global.config.awaitAuthentication
+import com.quizit.authentication.global.config.authentication
 import com.quizit.authentication.service.AuthenticationService
 import org.springframework.stereotype.Component
-import org.springframework.web.reactive.function.server.*
+import org.springframework.web.reactive.function.server.ServerRequest
+import org.springframework.web.reactive.function.server.ServerResponse
+import org.springframework.web.reactive.function.server.body
+import org.springframework.web.reactive.function.server.bodyToMono
+import reactor.core.publisher.Mono
 
 @Component
 class AuthenticationHandler(
     private val authenticationService: AuthenticationService
 ) {
-    suspend fun login(request: ServerRequest): ServerResponse =
-        request.awaitBody<LoginRequest>().let {
-            ServerResponse.ok().bodyValueAndAwait(authenticationService.login(it))
-        }
+    fun login(request: ServerRequest): Mono<ServerResponse> =
+        request.bodyToMono<LoginRequest>()
+            .flatMap {
+                ServerResponse.ok()
+                    .body(authenticationService.login(it))
+            }
 
-    suspend fun logout(request: ServerRequest): ServerResponse =
-        with(request.awaitAuthentication()) {
-            authenticationService.logout(id)
+    fun logout(request: ServerRequest): Mono<ServerResponse> =
+        request.authentication()
+            .flatMap {
+                ServerResponse.ok()
+                    .body(authenticationService.logout(it.id))
+            }
 
-            ServerResponse.ok().buildAndAwait()
-        }
-
-    suspend fun refresh(request: ServerRequest): ServerResponse =
-        request.awaitBody<RefreshRequest>().let {
-            ServerResponse.ok().bodyValueAndAwait(authenticationService.refresh(it))
-        }
+    fun refresh(request: ServerRequest): Mono<ServerResponse> =
+        request.bodyToMono<RefreshRequest>()
+            .flatMap {
+                ServerResponse.ok()
+                    .body(authenticationService.refresh(it))
+            }
 }

--- a/src/main/kotlin/com/quizit/authentication/router/AuthenticationRouter.kt
+++ b/src/main/kotlin/com/quizit/authentication/router/AuthenticationRouter.kt
@@ -5,13 +5,13 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.reactive.function.server.RouterFunction
 import org.springframework.web.reactive.function.server.ServerResponse
-import org.springframework.web.reactive.function.server.coRouter
+import org.springframework.web.reactive.function.server.router
 
 @Configuration
 class AuthenticationRouter {
     @Bean
     fun authenticationRoutes(handler: AuthenticationHandler): RouterFunction<ServerResponse> =
-        coRouter {
+        router {
             "/auth".nest {
                 GET("/logout", handler::logout)
                 POST("/login", handler::login)

--- a/src/main/kotlin/com/quizit/authentication/service/OAuth2Service.kt
+++ b/src/main/kotlin/com/quizit/authentication/service/OAuth2Service.kt
@@ -1,0 +1,17 @@
+//package com.quizit.authentication.service
+//
+//import org.springframework.security.oauth2.client.userinfo.DefaultReactiveOAuth2UserService
+//import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest
+//import org.springframework.security.oauth2.client.userinfo.ReactiveOAuth2UserService
+//import org.springframework.security.oauth2.core.user.OAuth2User
+//import org.springframework.stereotype.Service
+//import reactor.core.publisher.Mono
+//
+//@Service
+//class OAuth2Service : ReactiveOAuth2UserService<OAuth2UserRequest, OAuth2User> {
+//    override fun loadUser(request: OAuth2UserRequest): Mono<OAuth2User> {
+//        val oAuth2User = DefaultReactiveOAuth2UserService().loadUser(request)
+//        val provider = request.clientRegistration.registrationId
+//
+//    }
+//}

--- a/src/test/kotlin/com/quizit/authentication/controller/AuthenticationControllerTest.kt
+++ b/src/test/kotlin/com/quizit/authentication/controller/AuthenticationControllerTest.kt
@@ -20,13 +20,12 @@ import com.quizit.authentication.util.BaseControllerTest
 import com.quizit.authentication.util.desc
 import com.quizit.authentication.util.errorResponseFields
 import com.quizit.authentication.util.withMockUser
-import io.mockk.Runs
 import io.mockk.coEvery
-import io.mockk.just
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
 import org.springframework.restdocs.operation.preprocess.Preprocessors.*
 import org.springframework.restdocs.payload.PayloadDocumentation.requestFields
 import org.springframework.restdocs.payload.PayloadDocumentation.responseFields
+import reactor.core.publisher.Mono
 
 @WebFluxTest(AuthenticationHandler::class, AuthenticationRouter::class)
 class AuthenticationControllerTest : BaseControllerTest() {
@@ -69,7 +68,7 @@ class AuthenticationControllerTest : BaseControllerTest() {
     init {
         describe("login()은") {
             context("해당 아이디를 가진 유저가 존재하고 비밀번호가 일치하는 경우") {
-                coEvery { authenticationService.login(any()) } returns createLoginResponse()
+                coEvery { authenticationService.login(any()) } returns Mono.just(createLoginResponse())
 
                 it("상태 코드 200과 LoginResponse를 반환한다.") {
                     webClient
@@ -144,7 +143,7 @@ class AuthenticationControllerTest : BaseControllerTest() {
 
         describe("logout()은") {
             context("요청을 보낸 유저가 로그인 상태인 경우") {
-                coEvery { authenticationService.logout(any()) } just Runs
+                coEvery { authenticationService.logout(any()) } returns Mono.empty()
                 withMockUser()
 
                 it("상태 코드 200을 반환한다.") {
@@ -162,7 +161,8 @@ class AuthenticationControllerTest : BaseControllerTest() {
 
         describe("refresh()는") {
             context("요청을 보낸 유저가 로그인 상태인 경우") {
-                coEvery { authenticationService.refresh(any()) } returns createRefreshResponse()
+                coEvery { authenticationService.refresh(any()) } returns Mono.just(createRefreshResponse())
+                withMockUser()
 
                 it("상태 코드 200과 refreshResponse를 반환한다.") {
                     webClient
@@ -187,6 +187,7 @@ class AuthenticationControllerTest : BaseControllerTest() {
 
             context("요청을 보낸 유저의 리프레쉬 토큰이 저장소에 존재하지 않는 경우") {
                 coEvery { authenticationService.refresh(any()) } throws TokenNotFoundException()
+                withMockUser()
 
                 it("상태 코드 404와 에러를 반환한다.") {
                     webClient
@@ -211,6 +212,7 @@ class AuthenticationControllerTest : BaseControllerTest() {
 
             context("요청을 보낸 유저의 리프레쉬 토큰이 저장소에 있는 리프레쉬 토큰과 일치하지 않는 경우") {
                 coEvery { authenticationService.refresh(any()) } throws InvalidAccessException()
+                withMockUser()
 
                 it("상태 코드 403과 에러를 반환한다.") {
                     webClient

--- a/src/test/kotlin/com/quizit/authentication/fixture/JwtFixture.kt
+++ b/src/test/kotlin/com/quizit/authentication/fixture/JwtFixture.kt
@@ -10,12 +10,8 @@ val SECRET_KEY = (1..100).map { ('a'..'z').random() }.joinToString("")
 const val ACCESS_TOKEN_EXPIRE = 5L
 const val REFRESH_TOKEN_EXPIRE = 10L
 val AUTHORITIES = listOf(SimpleGrantedAuthority("USER"))
-const val INVALID_TOKEN = "test"
-val jwtProvider = JwtConfiguration().jwtProvider(
-    secretKey = SECRET_KEY,
-    accessTokenExpire = ACCESS_TOKEN_EXPIRE,
-    refreshTokenExpire = REFRESH_TOKEN_EXPIRE
-)
+const val INVALID_TOKEN = "invalid_token"
+val jwtProvider = JwtConfiguration().jwtProvider(SECRET_KEY, ACCESS_TOKEN_EXPIRE, REFRESH_TOKEN_EXPIRE)
 val ACCESS_TOKEN = jwtProvider.createAccessToken(createJwtAuthentication())
 val REFRESH_TOKEN = jwtProvider.createRefreshToken(createJwtAuthentication())
 

--- a/src/test/kotlin/com/quizit/authentication/fixture/JwtFixture.kt
+++ b/src/test/kotlin/com/quizit/authentication/fixture/JwtFixture.kt
@@ -3,13 +3,14 @@ package com.quizit.authentication.fixture
 import com.github.jwt.authentication.DefaultJwtAuthentication
 import com.github.jwt.config.JwtConfiguration
 import com.quizit.authentication.domain.Token
+import com.quizit.authentication.domain.enum.Role
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 
 val SECRET_KEY = (1..100).map { ('a'..'z').random() }.joinToString("")
 const val ACCESS_TOKEN_EXPIRE = 5L
 const val REFRESH_TOKEN_EXPIRE = 10L
-val AUTHORITIES = listOf(SimpleGrantedAuthority("USER"))
+val AUTHORITIES = listOf(SimpleGrantedAuthority(Role.USER.name))
 const val INVALID_TOKEN = "invalid_token"
 val jwtProvider = JwtConfiguration().jwtProvider(SECRET_KEY, ACCESS_TOKEN_EXPIRE, REFRESH_TOKEN_EXPIRE)
 val ACCESS_TOKEN = jwtProvider.createAccessToken(createJwtAuthentication())

--- a/src/test/kotlin/com/quizit/authentication/fixture/UserFixture.kt
+++ b/src/test/kotlin/com/quizit/authentication/fixture/UserFixture.kt
@@ -9,15 +9,15 @@ import java.time.LocalDateTime
 const val USERNAME = "earlgrey02@github.com"
 const val NICKNAME = "earlgrey02"
 const val PASSWORD = "root"
-const val IMAGE = "test"
+const val IMAGE = "http://localhost:8080/image.jpg"
 const val LEVEL = 2
 val ROLE = Role.USER
 const val ALLOW_PUSH = true
 const val DAILY_TARGET = 10
 const val ANSWER_RATE = 50.0
-val CORRECT_QUIZ_IDS = setOf("quiz_1")
-val INCORRECT_QUIZ_IDS = setOf("quiz_2")
-val MARKED_QUIZ_IDS = setOf("quiz_3")
+val CORRECT_QUIZ_IDS = hashSetOf("1")
+val INCORRECT_QUIZ_IDS = hashSetOf("1")
+val MARKED_QUIZ_IDS = hashSetOf("1")
 const val IS_MATCHED = true
 const val INVALID_USERNAME = "invalid_username"
 const val INVALID_PASSWORD = "invalid_password"
@@ -43,9 +43,9 @@ fun createUserResponse(
     dailyTarget: Int = DAILY_TARGET,
     answerRate: Double = ANSWER_RATE,
     createdDate: LocalDateTime = CREATED_DATE,
-    correctQuizIds: Set<String> = CORRECT_QUIZ_IDS,
-    incorrectQuizIds: Set<String> = INCORRECT_QUIZ_IDS,
-    markedQuizIds: Set<String> = MARKED_QUIZ_IDS,
+    correctQuizIds: HashSet<String> = CORRECT_QUIZ_IDS,
+    incorrectQuizIds: HashSet<String> = INCORRECT_QUIZ_IDS,
+    markedQuizIds: HashSet<String> = MARKED_QUIZ_IDS,
 ): UserResponse =
     UserResponse(
         id = id,

--- a/src/test/kotlin/com/quizit/authentication/repository/TokenRepositoryTest.kt
+++ b/src/test/kotlin/com/quizit/authentication/repository/TokenRepositoryTest.kt
@@ -9,10 +9,10 @@ import io.kotest.core.test.TestCase
 import io.kotest.matchers.equality.shouldBeEqualToComparingFields
 import io.kotest.matchers.equality.shouldNotBeEqualToComparingFields
 import io.kotest.matchers.nulls.shouldBeNull
-import kotlinx.coroutines.reactive.awaitSingle
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.redis.core.ReactiveRedisTemplate
 import org.springframework.test.context.ContextConfiguration
+import reactor.test.StepVerifier
 
 @ContextConfiguration(classes = [RedisTestConfiguration::class])
 class TokenRepositoryTest : ExpectSpec() {
@@ -27,35 +27,64 @@ class TokenRepositoryTest : ExpectSpec() {
     }
 
     override suspend fun beforeContainer(testCase: TestCase) {
-        redisTemplate.execute { it.serverCommands().flushAll() }.awaitSingle()
+        redisTemplate.execute {
+            it.serverCommands()
+                .flushAll()
+        }.subscribe()
     }
 
     init {
         context("리프레쉬 토큰 조회") {
-            val refreshToken = createToken().also { tokenRepository.save(it) }
+            val refreshToken = createToken()
+                .also {
+                    tokenRepository.save(it)
+                        .subscribe()
+                }
 
             expect("특정 유저의 리프레쉬 토큰을 조회한다.") {
-                tokenRepository.findByUserId(ID)!! shouldBeEqualToComparingFields refreshToken
+                val result = StepVerifier.create(tokenRepository.findByUserId(ID))
+
+                result.expectSubscription()
+                    .assertNext { it shouldBeEqualToComparingFields refreshToken }
+                    .verifyComplete()
             }
         }
 
         context("리프레쉬 토큰 수정") {
-            val refreshToken = createToken().also { tokenRepository.save(it) }
+            val refreshToken = createToken()
+                .also {
+                    tokenRepository.save(it)
+                        .subscribe()
+                }
 
             expect("특정 유저의 리프레쉬 토큰을 수정한다.") {
-                createToken(content = "test").let { tokenRepository.save(it) }
+                val result = StepVerifier.create(tokenRepository.save(createToken(content = "updated_content")))
 
-                tokenRepository.findByUserId(ID)!! shouldNotBeEqualToComparingFields refreshToken
+                result.expectSubscription()
+                    .assertNext {
+                        tokenRepository.findByUserId(ID)
+                            .subscribe { it shouldNotBeEqualToComparingFields refreshToken }
+                    }
+                    .verifyComplete()
             }
         }
 
         context("리프레쉬 토큰 삭제") {
-            createToken().let { tokenRepository.save(it) }
+            createToken()
+                .also {
+                    tokenRepository.save(it)
+                        .subscribe()
+                }
 
             expect("특정 유저의 리프레쉬 토큰을 삭제한다.") {
-                tokenRepository.deleteByUserId(ID)
+                val result = StepVerifier.create(tokenRepository.deleteByUserId(ID))
 
-                tokenRepository.findByUserId(ID).shouldBeNull()
+                result.expectSubscription()
+                    .assertNext {
+                        tokenRepository.findByUserId(ID)
+                            .subscribe { it.shouldBeNull() }
+                    }
+                    .verifyComplete()
             }
         }
     }

--- a/src/test/kotlin/com/quizit/authentication/util/TestUtil.kt
+++ b/src/test/kotlin/com/quizit/authentication/util/TestUtil.kt
@@ -9,10 +9,12 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.context.SecurityContextHolder
 
 infix fun String.desc(description: String): FieldDescriptor =
-    fieldWithPath(this).description(description)
+    fieldWithPath(this)
+        .description(description)
 
 infix fun String.paramDesc(description: String): ParameterDescriptor =
-    parameterWithName(this).description(description)
+    parameterWithName(this)
+        .description(description)
 
 fun withMockUser() {
     SecurityContextHolder.getContext().authentication = createJwtAuthentication()

--- a/src/test/kotlin/com/quizit/authentication/util/TestUtil.kt
+++ b/src/test/kotlin/com/quizit/authentication/util/TestUtil.kt
@@ -1,5 +1,6 @@
 package com.quizit.authentication.util
 
+import com.quizit.authentication.domain.enum.Role
 import com.quizit.authentication.fixture.createJwtAuthentication
 import org.springframework.restdocs.payload.FieldDescriptor
 import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
@@ -22,7 +23,7 @@ fun withMockUser() {
 
 fun withMockAdmin() {
     SecurityContextHolder.getContext().authentication =
-        createJwtAuthentication(authorities = listOf(SimpleGrantedAuthority("ADMIN")))
+        createJwtAuthentication(authorities = listOf(SimpleGrantedAuthority(Role.ADMIN.name)))
 }
 
 val errorResponseFields = listOf(


### PR DESCRIPTION
## 작업 내용

* **Spring WebFlux 환경에서 사용하던 Coroutine을 Reactive Streams 구현체인 Reactor로 대체**

## 코멘트

* 향후 추가될 Spring Reactive Stack 관련 기능들(OAuth, DynamoDB 등)에 대한 호환성 및 확장성을 위해 수행된 작업

## 관련 이슈

* **Close #34**